### PR TITLE
Changes notifications endpoint to take url parameters instead of json body

### DIFF
--- a/server/src/main/scala/hydra/notifications/http/NotificationsEndpoint.scala
+++ b/server/src/main/scala/hydra/notifications/http/NotificationsEndpoint.scala
@@ -49,7 +49,6 @@ class NotificationsEndpoint(implicit system: ActorSystem, implicit val e: Execut
     }
   }
 
-
   private def getServices(supervisor: ActorRef): Route = get {
     onSuccess(supervisor ? GetServiceList) { msg =>
       msg match {

--- a/server/src/test/scala/hydra/notifications/http/NotificationsEndpointSpec.scala
+++ b/server/src/test/scala/hydra/notifications/http/NotificationsEndpointSpec.scala
@@ -1,11 +1,10 @@
 package hydra.notifications.http
 
 import akka.actor.{Actor, ActorRef, Props}
-import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.testkit.{TestKit, TestProbe}
-import hydra.notifications.NotificationSent
 import hydra.notifications.client.{OpsGenieNotification, SlackNotification}
+import hydra.notifications.services.NotificationsSupervisor.SendNotification
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContextExecutor
@@ -19,49 +18,44 @@ class NotificationsEndpointSpec extends FlatSpec
 
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 
+  class ParentActor(to: ActorRef) extends Actor {
+    val childActor = context.actorOf(Props(new ForwardingActor(to)), "notifications_supervisor")
 
-
-  class ForwardingActor(to: ActorRef) extends Actor {
     override def receive: Receive = {
-      case NotificationSent(message) =>
-        println(s"OH HEY! I RECEIVED $message")
-        to.forward(message)
-        sender ! NotificationSent("message sent successfully")
+      case _ =>
     }
   }
 
-  val listener = TestProbe("service")
+  class ForwardingActor(to: ActorRef) extends Actor {
+    override def receive: Receive = {
+      case SendNotification(n) => to.forward(n)
+    }
+  }
 
-  val testNotificationSupervisor = system.actorOf(Props(new ForwardingActor(listener.ref)))
+  val listener = TestProbe()
 
-  "The notify/opsgenie endpoint" should
+  val notificationsSupervisor = system.actorOf(Props(new ParentActor(listener.ref)), "service")
+
+  "The /notify/opsgenie endpoint" should
     "create and send an OpsGenieNotification" in {
 
-    val route = new NotificationsEndpoint(Some(testNotificationSupervisor)).route
+    val route = new NotificationsEndpoint().route
 
     val request = Post("/notify/opsgenie?alias=scary_barry&team=team_awesome&tags=tag1,tag2&entity=da_entity&user=chunky_munkey")
-      .withEntity(
-        ContentTypes.`application/json`,
-        """
-           OH NOES OPSGENIE PLS HALP!
-        """.stripMargin)
+      .withEntity("""OH NOES OPSGENIE PLS HALP!""".stripMargin)
 
-    Post("/notify/opsgenie") ~> route ~> check {
+    request ~> route ~> check {
       listener.expectMsgType[OpsGenieNotification]
     }
   }
 
-  "The notify/slack endpoint" should
+  "The /notify/slack endpoint" should
     "create and send a Slack" in {
 
-    val route = new NotificationsEndpoint(Some(testNotificationSupervisor)).route
+    val route = new NotificationsEndpoint().route
 
     val request = Post("/notify/slack?channel=test_channel")
-      .withEntity(
-        ContentTypes.`application/json`,
-        """
-           OH NOES SLACK PLS HALP!
-        """.stripMargin)
+      .withEntity("""OH NOES SLACK PLS HALP!""".stripMargin)
 
     request ~> route ~> check {
       listener.expectMsgType[SlackNotification]

--- a/server/src/test/scala/hydra/notifications/http/NotificationsEndpointSpec.scala
+++ b/server/src/test/scala/hydra/notifications/http/NotificationsEndpointSpec.scala
@@ -1,0 +1,16 @@
+package hydra.notifications.http
+
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.testkit.TestKit
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+class NotificationsEndpointSpec extends FlatSpec
+  with Matchers
+  with ScalatestRouteTest
+  with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  "The notify/opsgenie/ endpoint" should
+    "create "
+}

--- a/server/src/test/scala/hydra/notifications/http/NotificationsEndpointSpec.scala
+++ b/server/src/test/scala/hydra/notifications/http/NotificationsEndpointSpec.scala
@@ -1,8 +1,14 @@
 package hydra.notifications.http
 
+import akka.actor.{Actor, ActorRef, Props}
+import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.testkit.TestKit
+import akka.testkit.{TestKit, TestProbe}
+import hydra.notifications.NotificationSent
+import hydra.notifications.client.{OpsGenieNotification, SlackNotification}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionContextExecutor
 
 class NotificationsEndpointSpec extends FlatSpec
   with Matchers
@@ -11,6 +17,54 @@ class NotificationsEndpointSpec extends FlatSpec
 
   override def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
-  "The notify/opsgenie/ endpoint" should
-    "create "
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+
+
+  class ForwardingActor(to: ActorRef) extends Actor {
+    override def receive: Receive = {
+      case NotificationSent(message) =>
+        println(s"OH HEY! I RECEIVED $message")
+        to.forward(message)
+        sender ! NotificationSent("message sent successfully")
+    }
+  }
+
+  val listener = TestProbe("service")
+
+  val testNotificationSupervisor = system.actorOf(Props(new ForwardingActor(listener.ref)))
+
+  "The notify/opsgenie endpoint" should
+    "create and send an OpsGenieNotification" in {
+
+    val route = new NotificationsEndpoint(Some(testNotificationSupervisor)).route
+
+    val request = Post("/notify/opsgenie?alias=scary_barry&team=team_awesome&tags=tag1,tag2&entity=da_entity&user=chunky_munkey")
+      .withEntity(
+        ContentTypes.`application/json`,
+        """
+           OH NOES OPSGENIE PLS HALP!
+        """.stripMargin)
+
+    Post("/notify/opsgenie") ~> route ~> check {
+      listener.expectMsgType[OpsGenieNotification]
+    }
+  }
+
+  "The notify/slack endpoint" should
+    "create and send a Slack" in {
+
+    val route = new NotificationsEndpoint(Some(testNotificationSupervisor)).route
+
+    val request = Post("/notify/slack?channel=test_channel")
+      .withEntity(
+        ContentTypes.`application/json`,
+        """
+           OH NOES SLACK PLS HALP!
+        """.stripMargin)
+
+    request ~> route ~> check {
+      listener.expectMsgType[SlackNotification]
+    }
+  }
 }


### PR DESCRIPTION
Instead of passing in a body such as `{"message": "some-message", "user": "some-user", etc...}` the endpoint now accepts either slack or opsgenie requests at `notify/slack` and `notify/opsgenie` respectively, and takes any message as a plain text body with all other fields being passed in as query parameters.  i.e. /notify/opsgenie?user=some-user&....